### PR TITLE
make switching b/w personal db and thai's db easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+db_init.php

--- a/db_init.php.dist
+++ b/db_init.php.dist
@@ -1,0 +1,7 @@
+<?php
+  // Define database connection constants
+  define('DB_HOST', 'classmysql.engr.oregonstate.edu');
+  define('DB_USER', 'cs340_YourOnid');
+  define('DB_PASSWORD', 'YourPassword');
+  define('DB_NAME', 'cs340_YourOnid');
+?>


### PR DESCRIPTION
changes
- [x] new file ``db_init.php.dist`` that you can copy to ``db_init.php`` and then include ``db_init.php`` in your php code so you don't have to type our your personal db creds all the time. Also, this way you don't have to publish your db passwords on github anymore.
- [x] new file ``.gitignore``: ignore your personal ``db_init.php`` so you don't have to expose your own db creds on github. 

usage
- cp ``db_init.php.dist`` ``db_init.php`` or whatever file name you want
- in your code:
``include 'db_init.php'`` or whatever you named the file
- ya 